### PR TITLE
Take a single pattern as a string rather than an array with one item

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,12 @@ function makeRe(pattern, shouldNegate) {
 
 module.exports = function (inputs, patterns) {
 	if (!(Array.isArray(inputs) && Array.isArray(patterns))) {
-		throw new TypeError('Expected two arrays, got ' + typeof inputs + ' ' + typeof patterns);
+		// If given pattern as a string, turn it into an array, otherwise throw
+		if (typeof patterns === 'string') {
+			patterns = [ patterns ];
+		} else {
+			throw new TypeError('Expected two arrays, got ' + typeof inputs + ' ' + typeof patterns);
+		}
 	}
 
 	if (patterns.length === 0) {

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ matcher.isMatch('unicorn', 'uni\\*');
 
 ### matcher(inputs, patterns)
 
-Accepts an array of `input`'s and `pattern`'s.
+`input` is an array of input. `patterns` is an array of patterns, or a single pattern as a string.
 
 Returns an array of of `inputs` filtered based on the `patterns`.
 

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,9 @@ matcher(['foo', 'bar', 'moo'], ['*oo', '!foo']);
 matcher(['foo', 'bar', 'moo'], ['!*oo']);
 //=> ['bar']
 
+matcher(['baz', 'foo', 'bar'], 'ba*');
+//=> ['baz', 'bar']
+
 matcher.isMatch('unicorn', 'uni*');
 //=> true
 

--- a/test.js
+++ b/test.js
@@ -1,13 +1,20 @@
 import test from 'ava';
 import m from './';
 
-test('matcher()', t => {
+test('matcher() given array', t => {
 	t.deepEqual(m(['foo', 'bar'], ['foo']), ['foo']);
 	t.deepEqual(m(['foo', 'bar'], ['bar']), ['bar']);
 	t.deepEqual(m(['foo', 'bar'], ['fo*', 'ba*', '!bar']), ['foo']);
 	t.deepEqual(m(['foo', 'bar', 'moo'], ['!*o']), ['bar']);
 
 	t.notThrows(() => m([], []));
+});
+
+test('matcher() given string', t => {
+	t.deepEqual(m(['foo', 'bar'], 'foo'), ['foo']);
+	t.deepEqual(m(['foo', 'bar'], 'bar'), ['bar']);
+	t.deepEqual(m(['foo', 'bar'], '!bar'), ['foo']);
+	t.deepEqual(m(['foo', 'bar', 'moo'], '!*o'), ['bar']);
 });
 
 test('matcher.isMatch()', t => {


### PR DESCRIPTION
This allows you to pass a single pattern as a string rather than an array with only one item.

```js
matcher(['baz', 'foo', 'bar'], 'ba*');
//=> ['baz', 'bar']
```