### PR TITLE
Support multiple inputs and patterns in `matcher.isMatch()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,9 +33,9 @@ declare const matcher: {
 	(inputs: readonly string[], patterns: readonly string[], options?: matcher.Options): string[];
 
 	/**
-	@param input - String to match.
-	@param pattern - Use `*` to match zero or more characters. A pattern starting with `!` will be negated.
-	@returns Whether the `input` matches the `pattern`.
+	@param input - String or array of strings to match.
+	@param pattern - String or array of string patterns. Use `*` to match zero or more characters. A pattern starting with `!` will be negated.
+	@returns Whether any given `input` matches every given `pattern`.
 
 	@example
 	```

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,9 +64,18 @@ declare const matcher: {
 
 	matcher.isMatch('UNICORN', 'unicorn', {caseSensitive: true});
 	//=> false
+
+	matcher.isMatch(['foo', 'bar'], 'f*');
+	//=> true
+
+	matcher.isMatch(['foo', 'bar'], ['a*', 'b*']);
+	//=> true
+
+	matcher.isMatch('unicorn', ['tri*', 'UNI*'], {caseSensitive: true});
+	//=> false
 	```
 	*/
-	isMatch(input: string, pattern: string, options?: matcher.Options): boolean;
+	isMatch(input: string | readonly string[], pattern: string | readonly string[], options?: matcher.Options): boolean;
 };
 
 export = matcher;

--- a/index.js
+++ b/index.js
@@ -64,7 +64,14 @@ module.exports = (inputs, patterns, options) => {
 };
 
 module.exports.isMatch = (input, pattern, options) => {
-	const regexp = makeRegexp(pattern, options);
-	const matches = regexp.test(input);
-	return regexp.negated ? !matches : matches;
+	const inputArray = Array.isArray(input) ? input : [input];
+	const patternArray = Array.isArray(pattern) ? pattern : [pattern];
+
+	return inputArray.some(input => {
+		return patternArray.every(pattern => {
+			const regexp = makeRegexp(pattern, options);
+			const matches = regexp.test(input);
+			return regexp.negated ? !matches : matches;
+		});
+	});
 };

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,9 @@ Returns an array of `inputs` filtered based on the `patterns`.
 
 ### matcher.isMatch(input, pattern, options?)
 
-Returns a `boolean` of whether the `input` matches the `pattern`.
+Accepts either a string or array of strings for both `input` and `pattern`.
+
+Returns a `boolean` of whether any given `input` matches every given `pattern`.
 
 #### input
 

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,15 @@ matcher.isMatch('UNICORN', 'UNI*', {caseSensitive: true});
 
 matcher.isMatch('UNICORN', 'unicorn', {caseSensitive: true});
 //=> false
+
+matcher.isMatch(['foo', 'bar'], 'f*');
+//=> true
+
+matcher.isMatch(['foo', 'bar'], ['a*', 'b*']);
+//=> true
+
+matcher.isMatch('unicorn', ['tri*', 'UNI*'], {caseSensitive: true});
+//=> false
 ```
 
 
@@ -65,9 +74,9 @@ Returns a `boolean` of whether any given `input` matches every given `pattern`.
 
 #### input
 
-Type: `string`
+Type: `string` or `string[]`
 
-String to match.
+String or array of strings to match.
 
 #### options
 
@@ -84,7 +93,7 @@ Ensure you use this correctly. For example, files and directories should be matc
 
 #### pattern
 
-Type: `string`
+Type: `string` or `string[]`
 
 Use `*` to match zero or more characters. A pattern starting with `!` will be negated.
 

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ Returns a `boolean` of whether any given `input` matches every given `pattern`.
 
 #### input
 
-Type: `string` or `string[]`
+Type: `string | string[]`
 
 String or array of strings to match.
 
@@ -93,7 +93,7 @@ Ensure you use this correctly. For example, files and directories should be matc
 
 #### pattern
 
-Type: `string` or `string[]`
+Type: `string | string[]`
 
 Use `*` to match zero or more characters. A pattern starting with `!` will be negated.
 

--- a/test.js
+++ b/test.js
@@ -28,4 +28,14 @@ test('matcher.isMatch()', t => {
 	t.false(matcher.isMatch('unicorn', 'uni\\*'));
 	t.true(matcher.isMatch('unicorn', '!tricorn'));
 	t.true(matcher.isMatch('unicorn', '!tri*'));
+
+	t.true(matcher.isMatch(['foo', 'bar', 'moo'], '*oo'));
+	t.true(matcher.isMatch(['foo', 'bar', 'moo'], ['*oo', '!f*']));
+	t.true(matcher.isMatch('moo', ['*oo', '!f*']));
+	t.true(matcher.isMatch('UNICORN', ['!*oo', 'UNI*'], {caseSensitive: true}));
+
+	t.false(matcher.isMatch(['unicorn', 'bar', 'wizard'], '*oo'));
+	t.false(matcher.isMatch(['foo', 'bar', 'unicorn'], ['*horn', '!b*']));
+	t.false(matcher.isMatch('moo', ['*oo', '!m*']));
+	t.false(matcher.isMatch('UNICORN', ['!*oo', 'uni*'], {caseSensitive: true}));
 });


### PR DESCRIPTION
Closes #15.

Add the ability to check whether _any given input_ satisfies _every given pattern_. Unlike #16 this implementation will short-circuit and return on the first matching input.

```js
// these return true:
matcher.isMatch(['foo', 'bar', 'moo'], '*oo');
matcher.isMatch(['foo', 'bar', 'moo'], ['*oo', '!f*']);
matcher.isMatch('moo', ['*oo', '!f*']);
matcher.isMatch('UNICORN', ['!*oo', 'UNI*'], {caseSensitive: true});

// these return false:
matcher.isMatch(['unicorn', 'bar', 'wizard'], '*oo');
matcher.isMatch(['foo', 'bar', 'unicorn'], ['*horn', '!b*']);
matcher.isMatch('moo', ['*oo', '!m*']);
matcher.isMatch('UNICORN', ['!*oo', 'uni*'], {caseSensitive: true});
```