### PR TITLE
Add `allPatterns` option

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -39,3 +39,11 @@ suite('matcher() - fixture', () => {
 suite('matcher.isMatch() - fixture', () => {
 	bench('test', () => matcher.isMatch(fixture, '*bar*'));
 });
+
+suite('matcher({every}) - fixture', () => {
+	const o = {every: true};
+	bench('multiple patterns', () => matcher(fixture.split(' '), ['*bar', '!foo', '!*oo'], o));
+	bench('zero or more chars', () => matcher(fixture.split(' '), ['*foo'], o));
+	bench('negation', () => matcher(fixture.split(' '), ['!foo'], o));
+	bench('negation zero or more', () => matcher(fixture.split(' '), ['!*foo'], o));
+});

--- a/bench.js
+++ b/bench.js
@@ -40,8 +40,8 @@ suite('matcher.isMatch() - fixture', () => {
 	bench('test', () => matcher.isMatch(fixture, '*bar*'));
 });
 
-suite('matcher({every}) - fixture', () => {
-	const o = {every: true};
+suite('matcher({allPatterns}) - fixture', () => {
+	const o = {allPatterns: true};
 	bench('multiple patterns', () => matcher(fixture.split(' '), ['*bar', '!foo', '!*oo'], o));
 	bench('zero or more chars', () => matcher(fixture.split(' '), ['*foo'], o));
 	bench('negation', () => matcher(fixture.split(' '), ['!foo'], o));

--- a/bench.js
+++ b/bench.js
@@ -41,9 +41,9 @@ suite('matcher.isMatch() - fixture', () => {
 });
 
 suite('matcher({allPatterns}) - fixture', () => {
-	const o = {allPatterns: true};
-	bench('multiple patterns', () => matcher(fixture.split(' '), ['*bar', '!foo', '!*oo'], o));
-	bench('zero or more chars', () => matcher(fixture.split(' '), ['*foo'], o));
-	bench('negation', () => matcher(fixture.split(' '), ['!foo'], o));
-	bench('negation zero or more', () => matcher(fixture.split(' '), ['!*foo'], o));
+	const options = {allPatterns: true};
+	bench('multiple patterns', () => matcher(fixture.split(' '), ['*bar', '!foo', '!*oo'], options));
+	bench('zero or more chars', () => matcher(fixture.split(' '), ['*foo'], options));
+	bench('negation', () => matcher(fixture.split(' '), ['!foo'], options));
+	bench('negation zero or more', () => matcher(fixture.split(' '), ['!*foo'], options));
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,9 @@
 declare namespace matcher {
 	interface Options {
 		/**
-		Requires every matcher() pattern to have at least one positive match.
+		Requires any negated pattern to never match and any normal pattern to match at once. Otherwise, it will be a no-match condition.
 
-		This option has no effect on isMatch().
+		This option may slow down the `matcher.isMatch` with long inputs.
 
 		@default false
 		*/
@@ -100,6 +100,12 @@ declare const matcher: {
 
 	matcher(['foo', 'bar', 'moo'], ['!*oo']);
 	//=> ['bar']
+
+	matcher(['foo', 'for', 'bar'], ['f*', 'b*', '!x*'], {allPatterns: true});
+	//=> ['foo', 'for', 'bar']
+
+	matcher(['foo', 'for', 'bar'], ['f*'], {allPatterns: true});
+	//=> []
 
 	matcher('moo', ['']);
 	//=> []

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ declare namespace matcher {
 
 		@example
 		```
-		//	Find text strings containing both "edge" and "tiger" in arbitrary order, but not "stunt".
+		// Find text strings containing both "edge" and "tiger" in arbitrary order, but not "stunt".
 		const demo = (strings) => matcher(strings, ['*edge*', '*tiger*', '!*stunt*'], {allPatterns: true});
 
 		demo(['Hey, tiger!', 'tiger has edge over hyenas', 'pushing a tiger over the edge is a stunt']);

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,14 @@
 declare namespace matcher {
 	interface Options {
 		/**
+		Requires every pattern for matcher() to have at least one positive match.
+
+		This option has no effect on isMatch() behavior.
+
+		@default false
+		*/
+		readonly every?: boolean;
+		/**
 		Treat uppercase and lowercase characters as being the same.
 
 		Ensure you use this correctly. For example, files and directories should be matched case-insensitively, while most often, object keys should be matched case-sensitively.

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ declare namespace matcher {
 		/**
 		Requires any negated pattern to never match and any normal pattern to match at once. Otherwise, it will be a no-match condition.
 
-		This option may slow down the `matcher.isMatch` with long inputs.
+		This option may slow down `matcher.isMatch` with long inputs.
 
 		@default false
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare namespace matcher {
 	interface Options {
 		/**
-		Requires any negated pattern to never match and any normal pattern to match at once. Otherwise, it will be a no-match condition.
+		Requires all negated patterns to not match and any normal patterns to match at least once. Otherwise, it will be a no-match condition.
 
 		This option may slow down `matcher.isMatch` with long inputs.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,9 @@
 declare namespace matcher {
 	interface Options {
 		/**
-		Requires every pattern for matcher() to have at least one positive match.
+		Requires every matcher() pattern to have at least one positive match.
 
-		This option has no effect on isMatch() behavior.
+		This option has no effect on isMatch().
 
 		@default false
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare namespace matcher {
 
 		@default false
 		*/
-		readonly every?: boolean;
+		readonly allPatterns?: boolean;
 		/**
 		Treat uppercase and lowercase characters as being the same.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,19 +1,6 @@
 declare namespace matcher {
 	interface Options {
 		/**
-		Requires all negated patterns to not match and any normal patterns to match at least once. Otherwise, it will be a no-match condition.
-
-		@default false
-
-		@example
-		```
-		//	Find text strings containing both "tiger" and "supremacy" in arbitrary order, but not "hoax".
-		const inputStrings = readSomeInputSource().split('\n')
-		const foundStrings = matcher(inputStrings, ['tiger', 'supremacy', '!hoax'], {allPatterns: true})
-		```
-		*/
-		readonly allPatterns?: boolean;
-		/**
 		Treat uppercase and lowercase characters as being the same.
 
 		Ensure you use this correctly. For example, files and directories should be matched case-insensitively, while most often, object keys should be matched case-sensitively.
@@ -21,6 +8,21 @@ declare namespace matcher {
 		@default false
 		*/
 		readonly caseSensitive?: boolean;
+		/**
+		Require all negated patterns to not match and any normal patterns to match at least once. Otherwise, it will be a no-match condition.
+
+		@default false
+
+		@example
+		```
+		//	Find text strings containing both "edge" and "tiger" in arbitrary order, but not "hoax".
+		const demo = (strings) => matcher(strings, ['edge', 'tiger', '!hoax'], {allPatterns: true});
+
+		demo(['Hey, tiger!', 'tiger has edge over hyenas', 'pushing a tiger over the edge might be a hoax']);
+		//=> ['tiger has edge over hyenas']
+		```
+		*/
+		readonly allPatterns?: boolean;
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,10 +15,10 @@ declare namespace matcher {
 
 		@example
 		```
-		//	Find text strings containing both "edge" and "tiger" in arbitrary order, but not "hoax".
-		const demo = (strings) => matcher(strings, ['edge', 'tiger', '!hoax'], {allPatterns: true});
+		//	Find text strings containing both "edge" and "tiger" in arbitrary order, but not "stunt".
+		const demo = (strings) => matcher(strings, ['*edge*', '*tiger*', '!*stunt*'], {allPatterns: true});
 
-		demo(['Hey, tiger!', 'tiger has edge over hyenas', 'pushing a tiger over the edge might be a hoax']);
+		demo(['Hey, tiger!', 'tiger has edge over hyenas', 'pushing a tiger over the edge is a stunt']);
 		//=> ['tiger has edge over hyenas']
 		```
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,9 +3,14 @@ declare namespace matcher {
 		/**
 		Requires all negated patterns to not match and any normal patterns to match at least once. Otherwise, it will be a no-match condition.
 
-		This option may slow down `matcher.isMatch` with long inputs.
-
 		@default false
+
+		@example
+		```
+		//	Find text strings containing both "tiger" and "supremacy" in arbitrary order, but not "hoax".
+		const inputStrings = readSomeInputSource().split('\n')
+		const foundStrings = matcher(inputStrings, ['tiger', 'supremacy', '!hoax'], {allPatterns: true})
+		```
 		*/
 		readonly allPatterns?: boolean;
 		/**

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ const matcher = (inputs, patterns, options, firstMatchOnly) => {
 	patterns = patterns.map(pattern => makeRegexp(pattern, options));
 
 	const {allPatterns} = options || {};
-	const didFit = new Uint8Array(patterns.length);
+	const didFit = [...patterns].fill(false);
 	const result = [];
 
 	for (const input of inputs) {
@@ -98,7 +98,7 @@ const matcher = (inputs, patterns, options, firstMatchOnly) => {
 	}
 
 	return (!allPatterns ||
-		didFit.every((flag, i) => flag ^ (patterns[i].negated & 1))) ? result : [];
+		didFit.every((flag, index) => flag ^ patterns[index].negated)) ? result : [];
 };
 
 module.exports = (inputs, patterns, options) => matcher(inputs, patterns, options, false);

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ const matcher = (inputs, patterns, options, firstMatchOnly) => {
 
 		if (!(matches === false ||
 			(matches === undefined && patterns.some(pattern => !pattern.negated)) ||
-			(allPatterns && didFit.some((flag, index) => !flag && !patterns[index].negated))
+			(allPatterns && didFit.some((yes, index) => !yes && !patterns[index].negated))
 		)) {
 			result.push(input);
 
@@ -99,6 +99,7 @@ const matcher = (inputs, patterns, options, firstMatchOnly) => {
 			}
 		}
 	}
+
 	return result;
 };
 

--- a/index.js
+++ b/index.js
@@ -68,14 +68,14 @@ const matcher = (inputs, patterns, options, firstMatchOnly) => {
 	patterns = patterns.map(pattern => makeRegexp(pattern, options));
 
 	const {allPatterns} = options || {};
-	const didFit = [...patterns].fill(false);
 	const result = [];
 
 	for (const input of inputs) {
-		let matches;
 		//	String is included only if it matches at least one non-negated pattern supplied.
 		//  Note: the `allPatterns` option requires every non-negated pattern to be matched once.
 		//	Matching a negated pattern excludes the string.
+		let matches;
+		const didFit = [...patterns].fill(false);
 
 		for (const [index, pattern] of patterns.entries()) {
 			if (pattern.test(input)) {
@@ -88,17 +88,18 @@ const matcher = (inputs, patterns, options, firstMatchOnly) => {
 			}
 		}
 
-		if (matches || (matches === undefined && !patterns.some(pattern => !pattern.negated))) {
+		if (!(matches === false ||
+			(matches === undefined && patterns.some(pattern => !pattern.negated)) ||
+			(allPatterns && didFit.some((flag, index) => !flag && !patterns[index].negated))
+		)) {
 			result.push(input);
 
-			if (firstMatchOnly && !allPatterns) {
+			if (firstMatchOnly) {
 				break;
 			}
 		}
 	}
-
-	return (!allPatterns ||
-		didFit.every((flag, index) => flag ^ patterns[index].negated)) ? result : [];
+	return result;
 };
 
 module.exports = (inputs, patterns, options) => matcher(inputs, patterns, options, false);

--- a/index.js
+++ b/index.js
@@ -40,18 +40,22 @@ module.exports = (inputs, patterns, options) => {
 	}
 
 	const isFirstPatternNegated = patterns[0][0] === '!';
+	const {every} = options || {};
 
 	patterns = patterns.map(pattern => makeRegexp(pattern, options));
 
 	const result = [];
+	const happies = patterns.map(rx => every ? (rx.negated ? 1 : 0) : 1);
 
 	for (const input of inputs) {
 		// If first pattern is negated we include everything to match user expectation.
 		let matches = isFirstPatternNegated;
 
-		for (const pattern of patterns) {
-			if (pattern.test(input)) {
-				matches = !pattern.negated;
+		for (let i = 0, pattern; i < patterns.length; ++i) {
+			if ((pattern = patterns[i]).test(input)) {
+				if ((matches = !pattern.negated)) {
+					happies[i] += 1;
+				}
 			}
 		}
 
@@ -60,7 +64,7 @@ module.exports = (inputs, patterns, options) => {
 		}
 	}
 
-	return result;
+	return happies.every(Boolean) ? result : [];
 };
 
 module.exports.isMatch = (input, pattern, options) => {

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function makeRegexp(pattern, options) {
 		return regexpCache.get(cacheKey);
 	}
 
-	const negated = pattern[0] === '!' ? 1 : 0;
+	const negated = pattern[0] === '!';
 
 	if (negated) {
 		pattern = pattern.slice(1);
@@ -97,7 +97,8 @@ const matcher = (inputs, patterns, options, firstMatchOnly) => {
 		}
 	}
 
-	return (!allPatterns || didFit.every((v, i) => v ^ patterns[i].negated)) ? result : [];
+	return (!allPatterns ||
+		didFit.every((flag, i) => flag ^ (patterns[i].negated & 1))) ? result : [];
 };
 
 module.exports = (inputs, patterns, options) => matcher(inputs, patterns, options, false);

--- a/index.js
+++ b/index.js
@@ -40,12 +40,12 @@ const matcher = (inputs, patterns, options) => {
 	}
 
 	const isFirstPatternNegated = patterns[0][0] === '!';
-	const {every} = options || {};
+	const {allPatterns} = options || {};
 
 	patterns = patterns.map(pattern => makeRegexp(pattern, options));
 
 	const result = [];
-	const matched = patterns.map(rx => every ? (rx.negated ? 1 : 0) : 1);
+	const matched = patterns.map(rx => allPatterns ? (rx.negated ? 1 : 0) : 1);
 
 	for (const input of inputs) {
 		// If first pattern is negated we include everything to match user expectation.
@@ -72,7 +72,7 @@ matcher.isMatch = (input, pattern, options = {}) => {
 	const patternArray = Array.isArray(pattern) ? pattern : [pattern];
 
 	return inputArray.some(item => {
-		return matcher([item], patternArray, {...options, every: true}).length !== 0;
+		return matcher([item], patternArray, {...options, allPatterns: true}).length !== 0;
 	});
 };
 

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ const matcher = (inputs, patterns, options, firstMatchOnly) => {
 	for (const input of inputs) {
 		let matches;
 		//	String is included only if it matches at least one non-negated pattern supplied.
-		//  NB: the `allPatterns` option requires every non-negated pattern to be matched once.
+		//  Note: the `allPatterns` option requires every non-negated pattern to be matched once.
 		//	Matching a negated pattern excludes the string.
 
 		for (let i = 0, pattern; (pattern = patterns[i]) !== undefined; i += 1) {

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ const matcher = (inputs, patterns, options, firstMatchOnly) => {
 
 		for (const [index, pattern] of patterns.entries()) {
 			if (pattern.test(input)) {
-				didFit[index] = 1;
+				didFit[index] = true;
 				matches = !pattern.negated;
 
 				if (!matches) {

--- a/index.js
+++ b/index.js
@@ -77,9 +77,9 @@ const matcher = (inputs, patterns, options, firstMatchOnly) => {
 		//  Note: the `allPatterns` option requires every non-negated pattern to be matched once.
 		//	Matching a negated pattern excludes the string.
 
-		for (let i = 0, pattern; (pattern = patterns[i]) !== undefined; i += 1) {
+		for (const [index, pattern] of patterns.entries()) {
 			if (pattern.test(input)) {
-				didFit[i] = 1;
+				didFit[index] = 1;
 				matches = !pattern.negated;
 
 				if (!matches) {

--- a/readme.md
+++ b/readme.md
@@ -128,10 +128,10 @@ Default: `false`
 Require all negated patterns to not match and any normal patterns to match at least once. Otherwise, it will be a no-match condition.
 
 ```js
-//	Find text strings containing both "edge" and "tiger" in arbitrary order, but not "hoax".
-const demo = (strings) => matcher(strings, ['edge', 'tiger', '!hoax'], {allPatterns: true});
+//  Find text strings containing both "edge" and "tiger" in arbitrary order, but not "stunt".
+const demo = (strings) => matcher(strings, ['*edge*', '*tiger*', '!*stunt*'], {allPatterns: true});
 
-demo(['Hey, tiger!', 'tiger has edge over hyenas', 'pushing a tiger over the edge might be a hoax']);
+demo(['Hey, tiger!', 'tiger has edge over hyenas', 'pushing a tiger over the edge is a stunt']);
 //=> ['tiger has edge over hyenas']
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -116,9 +116,15 @@ Type: `object`
 Type: `boolean`\
 Default: `false`
 
-Requires any negated pattern to never match and any normal pattern to match at once. Otherwise, it will be a no-match condition.
+Requires all negated patterns to not match and any normal patterns to match at least once. Otherwise, it will be a no-match condition.
 
 This option may slow down `matcher.isMatch` with long inputs.
+
+**Example:** find text strings containing both "Tesla" and "supremacy" in arbitrary order, but not "hoax".
+```javascript
+  const inputStrings = readSomeInputSource().split('\n')
+  const foundStrings = matcher(inputStrings, ['tesla', 'supremacy', '!hoax'], {allPatterns: true})
+```
 
 ##### caseSensitive
 

--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,7 @@ Default: `false`
 
 Requires any negated pattern to never match and any normal pattern to match at once. Otherwise, it will be a no-match condition.
 
-This option may slow down the `matcher.isMatch` with long inputs.
+This option may slow down `matcher.isMatch` with long inputs.
 
 ##### caseSensitive
 

--- a/readme.md
+++ b/readme.md
@@ -21,10 +21,10 @@ matcher(['foo', 'bar', 'moo'], ['*oo', '!foo']);
 matcher(['foo', 'bar', 'moo'], ['!*oo']);
 //=> ['bar']
 
-matcher(['a', 'b', 'c'], ['a*', 'c'], {every: true});
+matcher(['a', 'b', 'c'], ['a*', 'c'], {allPatterns: true});
 //=> ['a', 'c']
 
-matcher(['a', 'b', 'c'], ['a*', 'cc'], {every: true});
+matcher(['a', 'b', 'c'], ['a*', 'cc'], {allPatterns: true});
 //=> []
 
 matcher.isMatch('unicorn', 'uni*');
@@ -96,7 +96,7 @@ Treat uppercase and lowercase characters as being the same.
 
 Ensure you use this correctly. For example, files and directories should be matched case-insensitively, while most often, object keys should be matched case-sensitively.
 
-##### every
+##### allPatterns
 
 Type: `boolean`\
 Default: `false`

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,12 @@ matcher(['foo', 'bar', 'moo'], ['*oo', '!foo']);
 matcher(['foo', 'bar', 'moo'], ['!*oo']);
 //=> ['bar']
 
+matcher(['foo', 'for', 'bar'], ['f*', 'b*', '!x*'], {allPatterns: true});
+//=> ['foo', 'for', 'bar']
+
+matcher(['foo', 'for', 'bar'], ['f*'], {allPatterns: true});
+//=> []
+
 matcher('moo', ['']);
 //=> []
 
@@ -104,6 +110,15 @@ String or array of strings to match.
 #### options
 
 Type: `object`
+
+##### allPatterns
+
+Type: `boolean`\
+Default: `false`
+
+Requires any negated pattern to never match and any normal pattern to match at once. Otherwise, it will be a no-match condition.
+
+This option may slow down the `matcher.isMatch` with long inputs.
 
 ##### caseSensitive
 

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,12 @@ matcher(['foo', 'bar', 'moo'], ['*oo', '!foo']);
 matcher(['foo', 'bar', 'moo'], ['!*oo']);
 //=> ['bar']
 
+matcher(['a', 'b', 'c'], ['a*', 'c'], {every: true});
+//=> ['a', 'c']
+
+matcher(['a', 'b', 'c'], ['a*', 'cc'], {every: true});
+//=> []
+
 matcher.isMatch('unicorn', 'uni*');
 //=> true
 
@@ -89,6 +95,15 @@ Default: `false`
 Treat uppercase and lowercase characters as being the same.
 
 Ensure you use this correctly. For example, files and directories should be matched case-insensitively, while most often, object keys should be matched case-sensitively.
+
+##### every
+
+Type: `boolean`\
+Default: `false`
+
+Requires every _`matcher()`_ pattern to have at least one positive match.
+
+This option has no effect on _`isMatch()`_.
 
 #### pattern
 

--- a/readme.md
+++ b/readme.md
@@ -118,12 +118,10 @@ Default: `false`
 
 Requires all negated patterns to not match and any normal patterns to match at least once. Otherwise, it will be a no-match condition.
 
-This option may slow down `matcher.isMatch` with long inputs.
-
-**Example:** find text strings containing both "Tesla" and "supremacy" in arbitrary order, but not "hoax".
 ```javascript
-  const inputStrings = readSomeInputSource().split('\n')
-  const foundStrings = matcher(inputStrings, ['tesla', 'supremacy', '!hoax'], {allPatterns: true})
+//	Find text strings containing both "tiger" and "supremacy" in arbitrary order, but not "hoax".
+const inputStrings = readSomeInputSource().split('\n')
+const foundStrings = matcher(inputStrings, ['tiger', 'supremacy', '!hoax'], {allPatterns: true})
 ```
 
 ##### caseSensitive

--- a/readme.md
+++ b/readme.md
@@ -111,19 +111,6 @@ String or array of strings to match.
 
 Type: `object`
 
-##### allPatterns
-
-Type: `boolean`\
-Default: `false`
-
-Requires all negated patterns to not match and any normal patterns to match at least once. Otherwise, it will be a no-match condition.
-
-```javascript
-//	Find text strings containing both "tiger" and "supremacy" in arbitrary order, but not "hoax".
-const inputStrings = readSomeInputSource().split('\n')
-const foundStrings = matcher(inputStrings, ['tiger', 'supremacy', '!hoax'], {allPatterns: true})
-```
-
 ##### caseSensitive
 
 Type: `boolean`\
@@ -132,6 +119,21 @@ Default: `false`
 Treat uppercase and lowercase characters as being the same.
 
 Ensure you use this correctly. For example, files and directories should be matched case-insensitively, while most often, object keys should be matched case-sensitively.
+
+##### allPatterns
+
+Type: `boolean`\
+Default: `false`
+
+Require all negated patterns to not match and any normal patterns to match at least once. Otherwise, it will be a no-match condition.
+
+```js
+//	Find text strings containing both "edge" and "tiger" in arbitrary order, but not "hoax".
+const demo = (strings) => matcher(strings, ['edge', 'tiger', '!hoax'], {allPatterns: true});
+
+demo(['Hey, tiger!', 'tiger has edge over hyenas', 'pushing a tiger over the edge might be a hoax']);
+//=> ['tiger has edge over hyenas']
+```
 
 #### patterns
 

--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ Default: `false`
 Require all negated patterns to not match and any normal patterns to match at least once. Otherwise, it will be a no-match condition.
 
 ```js
-//  Find text strings containing both "edge" and "tiger" in arbitrary order, but not "stunt".
+// Find text strings containing both "edge" and "tiger" in arbitrary order, but not "stunt".
 const demo = (strings) => matcher(strings, ['*edge*', '*tiger*', '!*stunt*'], {allPatterns: true});
 
 demo(['Hey, tiger!', 'tiger has edge over hyenas', 'pushing a tiger over the edge is a stunt']);

--- a/test.js
+++ b/test.js
@@ -289,17 +289,28 @@ test('matcher.isMatch() negated pattern placement', t => {
 
 test('matcher() with allPatterns option', t => {
 	const flags = {allPatterns: true};
-	t.deepEqual(matcher(['foo', 'bar', 'for'], ['f*', 'b*'], flags), ['foo', 'bar', 'for']);
+
+	t.deepEqual(matcher('foo', '!x*', flags), ['foo']);
+	t.deepEqual(matcher(['foo', 'bar', 'for'], ['f*', 'b*'], flags), []);
 	t.deepEqual(matcher(['foo', 'bar', 'for'], ['f*', 'x*'], flags), []);
-	t.deepEqual(matcher(['foo', 'bar', 'for'], ['f*', '!b*'], flags), []);
+	t.deepEqual(matcher(['foo', 'bar', 'for'], ['f*', '!b*'], flags), ['foo', 'for']);
 	t.deepEqual(matcher(['foo', 'bar', 'for'], ['f*', '!x*'], flags), ['foo', 'for']);
+
+	t.deepEqual(matcher(
+		['Hey, tiger!', 'tiger has edge over hyenas', 'pushing a tiger over the edge is a stunt'],
+		['*edge*', '*tiger*', '!*stunt*'], flags), ['tiger has edge over hyenas']);
 });
 
 test('matcher.isMatch() with allPatterns option', t => {
 	const flags = {allPatterns: true};
-	t.true(matcher.isMatch(['foo', 'bar', 'for'], ['f*', 'b*'], flags));
+
+	t.true(matcher.isMatch('foo', '!x*', flags));
+	t.false(matcher.isMatch(['foo', 'bar', 'for'], ['f*', 'b*'], flags));
 	t.false(matcher.isMatch(['foo', 'bar', 'for'], ['f*', 'x*'], flags));
-	t.false(matcher.isMatch(['foo', 'bar', 'for'], ['f*', '!b*'], flags));
+	t.true(matcher.isMatch(['foo', 'bar', 'for'], ['f*', '!b*'], flags));
 	t.true(matcher.isMatch(['foo', 'bar', 'for'], ['f*', '!x*'], flags));
-	t.false(matcher.isMatch(['foo', 'bar'], ['!bar'], flags));
+	t.true(matcher.isMatch(['foo', 'bar'], ['!bar'], flags));
+	t.true(matcher.isMatch(
+		['Hey, tiger!', 'tiger has edge over hyenas', 'pushing a tiger over the edge is a stunt'],
+		['*edge*', '*tiger*', '!*stunt*'], flags));
 });

--- a/test.js
+++ b/test.js
@@ -47,14 +47,14 @@ test('matches across newlines', t => {
 	t.true(matcher.isMatch(['foo\nbar'], ['foo*r']));
 });
 
-test('matcher honors the \'every\' option', t => {
-	t.deepEqual(matcher(['a1', 'b', 'a2', 'c'], ['a*', 'c'], {every: true}), ['a1', 'a2', 'c']);
-	t.deepEqual(matcher(['a1', 'b', 'a2', 'c'], ['a*', 'c1'], {every: true}), []);
+test('matcher honors the \'allPatterns\' option', t => {
+	t.deepEqual(matcher(['a1', 'b', 'a2', 'c'], ['a*', 'c'], {allPatterns: true}), ['a1', 'a2', 'c']);
+	t.deepEqual(matcher(['a1', 'b', 'a2', 'c'], ['a*', 'c1'], {allPatterns: true}), []);
 });
 
-test('matcher.isEqual ignores the \'every\' option', t => {
-	t.true(matcher.isMatch(['a1', 'c'], ['c'], {every: true}));
-	t.false(matcher.isMatch(['a1', 'c'], ['c1'], {every: true}));
+test('matcher.isEqual ignores the \'allPatterns\' option', t => {
+	t.true(matcher.isMatch(['a1', 'c'], ['c'], {allPatterns: true}));
+	t.false(matcher.isMatch(['a1', 'c'], ['c1'], {allPatterns: true}));
 	t.true(matcher.isMatch(['a1', 'c'], ['c']));
 	t.false(matcher.isMatch(['a1', 'c'], ['c1']));
 });

--- a/test.js
+++ b/test.js
@@ -46,3 +46,15 @@ test('matches across newlines', t => {
 	t.true(matcher.isMatch(['foo\nbar'], ['foo*']));
 	t.true(matcher.isMatch(['foo\nbar'], ['foo*r']));
 });
+
+test('matcher honors the \'every\' option', t => {
+	t.deepEqual(matcher(['a1', 'b', 'a2', 'c'], ['a*', 'c'], {every: true}), ['a1', 'a2', 'c']);
+	t.deepEqual(matcher(['a1', 'b', 'a2', 'c'], ['a*', 'c1'], {every: true}), []);
+});
+
+test('matcher.isEqual ignores the \'every\' option', t => {
+	t.true(matcher.isMatch(['a1', 'c'], ['c'], {every: true}));
+	t.false(matcher.isMatch(['a1', 'c'], ['c1'], {every: true}));
+	t.true(matcher.isMatch(['a1', 'c'], ['c']));
+	t.false(matcher.isMatch(['a1', 'c'], ['c1']));
+});

--- a/test.js
+++ b/test.js
@@ -286,3 +286,20 @@ test('matcher.isMatch() negated pattern placement', t => {
 	t.true(matcher.isMatch(['foo', 'bar'], ['!bar', 'fo*', '*oo']));
 	t.true(matcher.isMatch(['foo', 'bar'], ['!bar']));
 });
+
+test('matcher() with allPatterns option', t => {
+	const flags = {allPatterns: true};
+	t.deepEqual(matcher(['foo', 'bar', 'for'], ['f*', 'b*'], flags), ['foo', 'bar', 'for']);
+	t.deepEqual(matcher(['foo', 'bar', 'for'], ['f*', 'x*'], flags), []);
+	t.deepEqual(matcher(['foo', 'bar', 'for'], ['f*', '!b*'], flags), []);
+	t.deepEqual(matcher(['foo', 'bar', 'for'], ['f*', '!x*'], flags), ['foo', 'for']);
+});
+
+test('matcher.isMatch() with allPatterns option', t => {
+	const flags = {allPatterns: true};
+	t.true(matcher.isMatch(['foo', 'bar', 'for'], ['f*', 'b*'], flags));
+	t.false(matcher.isMatch(['foo', 'bar', 'for'], ['f*', 'x*'], flags));
+	t.false(matcher.isMatch(['foo', 'bar', 'for'], ['f*', '!b*'], flags));
+	t.true(matcher.isMatch(['foo', 'bar', 'for'], ['f*', '!x*'], flags));
+	t.false(matcher.isMatch(['foo', 'bar'], ['!bar'], flags));
+});

--- a/test.js
+++ b/test.js
@@ -296,9 +296,14 @@ test('matcher() with allPatterns option', t => {
 	t.deepEqual(matcher(['foo', 'bar', 'for'], ['f*', '!b*'], flags), ['foo', 'for']);
 	t.deepEqual(matcher(['foo', 'bar', 'for'], ['f*', '!x*'], flags), ['foo', 'for']);
 
-	t.deepEqual(matcher(
-		['Hey, tiger!', 'tiger has edge over hyenas', 'pushing a tiger over the edge is a stunt'],
-		['*edge*', '*tiger*', '!*stunt*'], flags), ['tiger has edge over hyenas']);
+	t.deepEqual(
+		matcher(
+			['Hey, tiger!', 'tiger has edge over hyenas', 'pushing a tiger over the edge is a stunt'],
+			['*edge*', '*tiger*', '!*stunt*'],
+			flags
+		),
+		['tiger has edge over hyenas']
+	);
 });
 
 test('matcher.isMatch() with allPatterns option', t => {
@@ -310,7 +315,11 @@ test('matcher.isMatch() with allPatterns option', t => {
 	t.true(matcher.isMatch(['foo', 'bar', 'for'], ['f*', '!b*'], flags));
 	t.true(matcher.isMatch(['foo', 'bar', 'for'], ['f*', '!x*'], flags));
 	t.true(matcher.isMatch(['foo', 'bar'], ['!bar'], flags));
-	t.true(matcher.isMatch(
-		['Hey, tiger!', 'tiger has edge over hyenas', 'pushing a tiger over the edge is a stunt'],
-		['*edge*', '*tiger*', '!*stunt*'], flags));
+	t.true(
+		matcher.isMatch(
+			['Hey, tiger!', 'tiger has edge over hyenas', 'pushing a tiger over the edge is a stunt'],
+			['*edge*', '*tiger*', '!*stunt*'],
+			flags
+		)
+	);
 });


### PR DESCRIPTION
The need for the new 'allPatterns' option emerged when writing an utility applying an aggregated pattern match on source files.

I did not modify the `index.test-d.ts` file, because I was not sure of its purpose.

Happy new year!
Villem

Fixes #25