### PR TITLE
Standardize handling of empty arguments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,8 +17,8 @@ declare const matcher: {
 
 	It matches even across newlines. For example, `foo*r` will match `foo\nbar`.
 
-	@param inputs - Strings to match.
-	@param patterns - Use `*` to match zero or more characters. A pattern starting with `!` will be negated.
+	@param inputs - String or array of strings to match.
+	@param patterns - String or array of string patterns. Use `*` to match zero or more characters. A pattern starting with `!` will be negated.
 	@returns The `inputs` filtered based on the `patterns`.
 
 	@example
@@ -30,15 +30,24 @@ declare const matcher: {
 
 	matcher(['foo', 'bar', 'moo'], ['!*oo']);
 	//=> ['bar']
+
+	matcher('moo', ['']);
+	//=> []
+
+	matcher('moo', []);
+	//=> []
+
+	matcher([''], ['']);
+	//=> ['']
 	```
 	*/
-	(inputs: readonly string[], patterns: readonly string[], options?: matcher.Options): string[];
+	(inputs: string | readonly string[], patterns: string | readonly string[], options?: matcher.Options): string[];
 
 	/**
 	It matches even across newlines. For example, `foo*r` will match `foo\nbar`.
 
-	@param input - String or array of strings to match.
-	@param pattern - String or array of string patterns. Use `*` to match zero or more characters. A pattern starting with `!` will be negated.
+	@param inputs - String or array of strings to match.
+	@param patterns - String or array of string patterns. Use `*` to match zero or more characters. A pattern starting with `!` will be negated.
 	@returns Whether any given `input` matches every given `pattern`.
 
 	@example
@@ -77,9 +86,24 @@ declare const matcher: {
 
 	matcher.isMatch('unicorn', ['tri*', 'UNI*'], {caseSensitive: true});
 	//=> false
+
+	matcher.isMatch('unicorn', ['']);
+	//=> false
+
+	matcher.isMatch('unicorn', []);
+	//=> false
+
+	matcher.isMatch([], 'bar');
+	//=> false
+
+	matcher.isMatch([], []);
+	//=> false
+
+	matcher.isMatch([''], ['']);
+	//=> true
 	```
 	*/
-	isMatch: (input: string | readonly string[], pattern: string | readonly string[], options?: matcher.Options) => boolean;
+	isMatch: (inputs: string | readonly string[], patterns: string | readonly string[], options?: matcher.Options) => boolean;
 };
 
 export = matcher;

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,15 @@ matcher(['foo', 'bar', 'moo'], ['*oo', '!foo']);
 matcher(['foo', 'bar', 'moo'], ['!*oo']);
 //=> ['bar']
 
+matcher('moo', ['']);
+//=> []
+
+matcher('moo', []);
+//=> []
+
+matcher([''], ['']);
+//=> ['']
+
 matcher.isMatch('unicorn', 'uni*');
 //=> true
 
@@ -53,6 +62,21 @@ matcher.isMatch(['foo', 'bar'], ['a*', 'b*']);
 
 matcher.isMatch('unicorn', ['tri*', 'UNI*'], {caseSensitive: true});
 //=> false
+
+matcher.isMatch('unicorn', ['']);
+//=> false
+
+matcher.isMatch('unicorn', []);
+//=> false
+
+matcher.isMatch([], 'bar');
+//=> false
+
+matcher.isMatch([], []);
+//=> false
+
+matcher.isMatch('', '');
+//=> true
 ```
 
 ## API
@@ -61,13 +85,13 @@ It matches even across newlines. For example, `foo*r` will match `foo\nbar`.
 
 ### matcher(inputs, patterns, options?)
 
-Accepts an array of `input`'s and `pattern`'s.
+Accepts a string or an array of strings for both `inputs` and `patterns`.
 
 Returns an array of `inputs` filtered based on the `patterns`.
 
 ### matcher.isMatch(input, pattern, options?)
 
-Accepts either a string or array of strings for both `input` and `pattern`.
+Accepts a string or an array of strings for both `inputs` and `patterns`.
 
 Returns a `boolean` of whether any given `input` matches every given `pattern`.
 

--- a/test.js
+++ b/test.js
@@ -46,3 +46,127 @@ test('matches across newlines', t => {
 	t.true(matcher.isMatch(['foo\nbar'], ['foo*']));
 	t.true(matcher.isMatch(['foo\nbar'], ['foo*r']));
 });
+
+test('handles empty arguments inconsistently', t => {
+	t.deepEqual(matcher(['phoenix'], ['bar', '']), []);
+	t.deepEqual(matcher(['phoenix'], ['', 'bar']), []);
+	t.deepEqual(matcher(['phoenix'], ['', 'bar', '']), []);
+	t.deepEqual(matcher(['phoenix'], ['bar', '', 'bar']), []);
+	t.throws(() => matcher(['phoenix'], [undefined, '']));
+	t.throws(() => matcher(['phoenix'], ['', undefined]));
+	t.throws(() => matcher(['phoenix'], ['', undefined, '']));
+	t.throws(() => matcher(['phoenix'], [undefined, '', undefined]));
+	t.deepEqual(matcher(['phoenix'], ['', '']), []);
+	t.deepEqual(matcher(['phoenix'], ['']), []);
+	t.deepEqual(matcher(['phoenix'], []), ['phoenix']);
+	t.throws(() => matcher(['phoenix'], [undefined]));
+
+	t.throws(() => matcher(['phoenix'], ''));
+	t.throws(() => matcher(['phoenix'], undefined));
+
+	t.deepEqual(matcher(['phoenix', ''], ['bar']), []);
+	t.deepEqual(matcher(['', 'phoenix'], ['bar']), []);
+	t.deepEqual(matcher(['', 'phoenix', ''], ['bar']), []);
+	t.deepEqual(matcher(['phoenix', '', 'phoenix'], ['bar']), []);
+	t.deepEqual(matcher([undefined, ''], ['bar']), []);
+	t.deepEqual(matcher(['', undefined], ['bar']), []);
+	t.deepEqual(matcher(['', undefined, ''], ['bar']), []);
+	t.deepEqual(matcher([undefined, '', undefined], ['bar']), []);
+	t.deepEqual(matcher(['', ''], ['bar']), []);
+	t.deepEqual(matcher([''], ['bar']), []);
+	t.deepEqual(matcher([], ['bar']), []);
+	t.deepEqual(matcher([undefined], ['bar']), []);
+
+	t.throws(() => matcher('', ['bar']));
+	t.throws(() => matcher(undefined, ['bar']));
+
+	t.false(matcher.isMatch(['phoenix'], ['bar', '']));
+	t.false(matcher.isMatch(['phoenix'], ['', 'bar']));
+	t.false(matcher.isMatch(['phoenix'], ['', 'bar', '']));
+	t.false(matcher.isMatch(['phoenix'], ['bar', '', 'bar']));
+	t.throws(() => matcher.isMatch(['phoenix'], [undefined, '']));
+	t.false(matcher.isMatch(['phoenix'], ['', undefined]));
+	t.false(matcher.isMatch(['phoenix'], ['', undefined, '']));
+	t.throws(() => matcher.isMatch(['phoenix'], [undefined, '', undefined]));
+	t.false(matcher.isMatch(['phoenix'], ['', '']));
+	t.false(matcher.isMatch(['phoenix'], ['']));
+	t.false(matcher.isMatch(['phoenix'], ''));
+	t.true(matcher.isMatch(['phoenix'], []));
+	t.throws(() => matcher.isMatch(['phoenix'], [undefined]));
+	t.throws(() => matcher.isMatch(['phoenix'], undefined));
+
+	t.false(matcher.isMatch(['phoenix', ''], ['bar']));
+	t.false(matcher.isMatch(['', 'phoenix'], ['bar']));
+	t.false(matcher.isMatch(['', 'phoenix', ''], ['bar']));
+	t.false(matcher.isMatch(['phoenix', '', 'phoenix'], ['bar']));
+	t.false(matcher.isMatch([undefined, ''], ['bar']));
+	t.false(matcher.isMatch(['', undefined], ['bar']));
+	t.false(matcher.isMatch(['', undefined, ''], ['bar']));
+	t.false(matcher.isMatch([undefined, '', undefined], ['bar']));
+	t.false(matcher.isMatch(['', ''], ['bar']));
+	t.false(matcher.isMatch([''], ['bar']));
+	t.false(matcher.isMatch('', ['bar']));
+	t.false(matcher.isMatch([], ['bar']));
+	t.false(matcher.isMatch([undefined], ['bar']));
+	t.false(matcher.isMatch(undefined, ['bar']));
+
+	t.deepEqual(matcher([''], ['bar', '']), ['']);
+	t.deepEqual(matcher([''], ['', 'bar']), ['']);
+	t.throws(() => matcher([''], [undefined, '']));
+	t.throws(() => matcher([''], ['', undefined]));
+	t.deepEqual(matcher([''], ['', '']), ['']);
+	t.deepEqual(matcher([''], ['']), ['']);
+
+	t.deepEqual(matcher(['phoenix', ''], ['']), ['']);
+	t.deepEqual(matcher(['', 'phoenix'], ['']), ['']);
+	t.deepEqual(matcher([undefined, ''], ['']), ['']);
+	t.deepEqual(matcher(['', undefined], ['']), ['']);
+	t.deepEqual(matcher(['', ''], ['']), ['', '']);
+	t.deepEqual(matcher([''], ['']), ['']);
+
+	t.throws(() => matcher([undefined], ['bar', undefined]));
+	t.throws(() => matcher([undefined], [undefined, 'bar']));
+	t.throws(() => matcher([undefined], ['', undefined]));
+	t.throws(() => matcher([undefined], [undefined, '']));
+	t.throws(() => matcher([undefined], [undefined, undefined]));
+	t.throws(() => matcher([undefined], [undefined]));
+	t.throws(() => matcher([undefined], undefined));
+
+	t.throws(() => matcher(['phoenix', undefined], [undefined]));
+	t.throws(() => matcher([undefined, 'phoenix'], [undefined]));
+	t.throws(() => matcher(['', undefined], [undefined]));
+	t.throws(() => matcher([undefined, ''], [undefined]));
+	t.throws(() => matcher([undefined, undefined], [undefined]));
+	t.throws(() => matcher([undefined], [undefined]));
+	t.throws(() => matcher(undefined, [undefined]));
+
+	t.false(matcher.isMatch([''], ['bar', '']));
+	t.false(matcher.isMatch([''], ['', 'bar']));
+	t.throws(() => matcher.isMatch([''], [undefined, '']));
+	t.throws(() => matcher.isMatch([''], ['', undefined]));
+	t.true(matcher.isMatch([''], ['', '']));
+	t.true(matcher.isMatch([''], ['']));
+
+	t.true(matcher.isMatch(['phoenix', ''], ['']));
+	t.true(matcher.isMatch(['', 'phoenix'], ['']));
+	t.true(matcher.isMatch([undefined, ''], ['']));
+	t.true(matcher.isMatch(['', undefined], ['']));
+	t.true(matcher.isMatch(['', ''], ['']));
+	t.true(matcher.isMatch([''], ['']));
+
+	t.false(matcher.isMatch([undefined], ['bar', undefined]));
+	t.throws(() => matcher.isMatch([undefined], [undefined, 'bar']));
+	t.false(matcher.isMatch([undefined], ['', undefined]));
+	t.throws(() => matcher.isMatch([undefined], [undefined, '']));
+	t.throws(() => matcher.isMatch([undefined], [undefined, undefined]));
+	t.throws(() => matcher.isMatch([undefined], [undefined]));
+	t.throws(() => matcher.isMatch([undefined], undefined));
+
+	t.throws(() => matcher.isMatch(['phoenix', undefined], [undefined]));
+	t.throws(() => matcher.isMatch([undefined, 'phoenix'], [undefined]));
+	t.throws(() => matcher.isMatch(['', undefined], [undefined]));
+	t.throws(() => matcher.isMatch([undefined, ''], [undefined]));
+	t.throws(() => matcher.isMatch([undefined, undefined], [undefined]));
+	t.throws(() => matcher.isMatch([undefined], [undefined]));
+	t.throws(() => matcher.isMatch(undefined, [undefined]));
+});

--- a/test.js
+++ b/test.js
@@ -47,22 +47,21 @@ test('matches across newlines', t => {
 	t.true(matcher.isMatch(['foo\nbar'], ['foo*r']));
 });
 
-test('handles empty arguments inconsistently', t => {
+test('handles empty arguments consistently', t => {
 	t.deepEqual(matcher(['phoenix'], ['bar', '']), []);
 	t.deepEqual(matcher(['phoenix'], ['', 'bar']), []);
 	t.deepEqual(matcher(['phoenix'], ['', 'bar', '']), []);
 	t.deepEqual(matcher(['phoenix'], ['bar', '', 'bar']), []);
-	t.throws(() => matcher(['phoenix'], [undefined, '']));
-	t.throws(() => matcher(['phoenix'], ['', undefined]));
-	t.throws(() => matcher(['phoenix'], ['', undefined, '']));
-	t.throws(() => matcher(['phoenix'], [undefined, '', undefined]));
+	t.deepEqual(matcher(['phoenix'], [undefined, '']), []);
+	t.deepEqual(matcher(['phoenix'], ['', undefined]), []);
+	t.deepEqual(matcher(['phoenix'], ['', undefined, '']), []);
+	t.deepEqual(matcher(['phoenix'], [undefined, '', undefined]), []);
 	t.deepEqual(matcher(['phoenix'], ['', '']), []);
 	t.deepEqual(matcher(['phoenix'], ['']), []);
-	t.deepEqual(matcher(['phoenix'], []), ['phoenix']);
-	t.throws(() => matcher(['phoenix'], [undefined]));
-
-	t.throws(() => matcher(['phoenix'], ''));
-	t.throws(() => matcher(['phoenix'], undefined));
+	t.deepEqual(matcher(['phoenix'], ''), []);
+	t.deepEqual(matcher(['phoenix'], []), []);
+	t.deepEqual(matcher(['phoenix'], [undefined]), []);
+	t.deepEqual(matcher(['phoenix'], undefined), []);
 
 	t.deepEqual(matcher(['phoenix', ''], ['bar']), []);
 	t.deepEqual(matcher(['', 'phoenix'], ['bar']), []);
@@ -74,26 +73,25 @@ test('handles empty arguments inconsistently', t => {
 	t.deepEqual(matcher([undefined, '', undefined], ['bar']), []);
 	t.deepEqual(matcher(['', ''], ['bar']), []);
 	t.deepEqual(matcher([''], ['bar']), []);
+	t.deepEqual(matcher('', ['bar']), []);
 	t.deepEqual(matcher([], ['bar']), []);
 	t.deepEqual(matcher([undefined], ['bar']), []);
-
-	t.throws(() => matcher('', ['bar']));
-	t.throws(() => matcher(undefined, ['bar']));
+	t.deepEqual(matcher(undefined, ['bar']), []);
 
 	t.false(matcher.isMatch(['phoenix'], ['bar', '']));
 	t.false(matcher.isMatch(['phoenix'], ['', 'bar']));
 	t.false(matcher.isMatch(['phoenix'], ['', 'bar', '']));
 	t.false(matcher.isMatch(['phoenix'], ['bar', '', 'bar']));
-	t.throws(() => matcher.isMatch(['phoenix'], [undefined, '']));
+	t.false(matcher.isMatch(['phoenix'], [undefined, '']));
 	t.false(matcher.isMatch(['phoenix'], ['', undefined]));
 	t.false(matcher.isMatch(['phoenix'], ['', undefined, '']));
-	t.throws(() => matcher.isMatch(['phoenix'], [undefined, '', undefined]));
+	t.false(matcher.isMatch(['phoenix'], [undefined, '', undefined]));
 	t.false(matcher.isMatch(['phoenix'], ['', '']));
 	t.false(matcher.isMatch(['phoenix'], ['']));
 	t.false(matcher.isMatch(['phoenix'], ''));
-	t.true(matcher.isMatch(['phoenix'], []));
-	t.throws(() => matcher.isMatch(['phoenix'], [undefined]));
-	t.throws(() => matcher.isMatch(['phoenix'], undefined));
+	t.false(matcher.isMatch(['phoenix'], []));
+	t.false(matcher.isMatch(['phoenix'], [undefined]));
+	t.false(matcher.isMatch(['phoenix'], undefined));
 
 	t.false(matcher.isMatch(['phoenix', ''], ['bar']));
 	t.false(matcher.isMatch(['', 'phoenix'], ['bar']));
@@ -112,61 +110,95 @@ test('handles empty arguments inconsistently', t => {
 
 	t.deepEqual(matcher([''], ['bar', '']), ['']);
 	t.deepEqual(matcher([''], ['', 'bar']), ['']);
-	t.throws(() => matcher([''], [undefined, '']));
-	t.throws(() => matcher([''], ['', undefined]));
+	t.deepEqual(matcher([''], [undefined, '']), ['']);
+	t.deepEqual(matcher([''], ['', undefined]), ['']);
 	t.deepEqual(matcher([''], ['', '']), ['']);
-	t.deepEqual(matcher([''], ['']), ['']);
 
 	t.deepEqual(matcher(['phoenix', ''], ['']), ['']);
 	t.deepEqual(matcher(['', 'phoenix'], ['']), ['']);
 	t.deepEqual(matcher([undefined, ''], ['']), ['']);
 	t.deepEqual(matcher(['', undefined], ['']), ['']);
 	t.deepEqual(matcher(['', ''], ['']), ['', '']);
+
 	t.deepEqual(matcher([''], ['']), ['']);
+	t.deepEqual(matcher([''], ['*']), ['']);
 
-	t.throws(() => matcher([undefined], ['bar', undefined]));
-	t.throws(() => matcher([undefined], [undefined, 'bar']));
-	t.throws(() => matcher([undefined], ['', undefined]));
-	t.throws(() => matcher([undefined], [undefined, '']));
-	t.throws(() => matcher([undefined], [undefined, undefined]));
-	t.throws(() => matcher([undefined], [undefined]));
-	t.throws(() => matcher([undefined], undefined));
+	t.deepEqual(matcher([undefined], ['bar', undefined]), []);
+	t.deepEqual(matcher([undefined], [undefined, 'bar']), []);
+	t.deepEqual(matcher([undefined], ['', undefined]), []);
+	t.deepEqual(matcher([undefined], [undefined, '']), []);
+	t.deepEqual(matcher([undefined], [undefined, undefined]), []);
+	t.deepEqual(matcher([undefined], [undefined]), []);
+	t.deepEqual(matcher([undefined], undefined), []);
 
-	t.throws(() => matcher(['phoenix', undefined], [undefined]));
-	t.throws(() => matcher([undefined, 'phoenix'], [undefined]));
-	t.throws(() => matcher(['', undefined], [undefined]));
-	t.throws(() => matcher([undefined, ''], [undefined]));
-	t.throws(() => matcher([undefined, undefined], [undefined]));
-	t.throws(() => matcher([undefined], [undefined]));
-	t.throws(() => matcher(undefined, [undefined]));
+	t.deepEqual(matcher(['phoenix', undefined], [undefined]), []);
+	t.deepEqual(matcher([undefined, 'phoenix'], [undefined]), []);
+	t.deepEqual(matcher(['', undefined], [undefined]), []);
+	t.deepEqual(matcher([undefined, ''], [undefined]), []);
+	t.deepEqual(matcher([undefined, undefined], [undefined]), []);
+	t.deepEqual(matcher([undefined], [undefined]), []);
+	t.deepEqual(matcher(undefined, [undefined]), []);
 
-	t.false(matcher.isMatch([''], ['bar', '']));
-	t.false(matcher.isMatch([''], ['', 'bar']));
-	t.throws(() => matcher.isMatch([''], [undefined, '']));
-	t.throws(() => matcher.isMatch([''], ['', undefined]));
+	t.deepEqual(matcher([], []), []);
+	t.deepEqual(matcher([], ['*']), []);
+
+	t.true(matcher.isMatch([''], [undefined, '']));
+	t.true(matcher.isMatch([''], ['', undefined]));
 	t.true(matcher.isMatch([''], ['', '']));
-	t.true(matcher.isMatch([''], ['']));
 
 	t.true(matcher.isMatch(['phoenix', ''], ['']));
 	t.true(matcher.isMatch(['', 'phoenix'], ['']));
 	t.true(matcher.isMatch([undefined, ''], ['']));
 	t.true(matcher.isMatch(['', undefined], ['']));
 	t.true(matcher.isMatch(['', ''], ['']));
+
 	t.true(matcher.isMatch([''], ['']));
+	t.true(matcher.isMatch([''], ['*']));
 
 	t.false(matcher.isMatch([undefined], ['bar', undefined]));
-	t.throws(() => matcher.isMatch([undefined], [undefined, 'bar']));
+	t.false(matcher.isMatch([undefined], [undefined, 'bar']));
 	t.false(matcher.isMatch([undefined], ['', undefined]));
-	t.throws(() => matcher.isMatch([undefined], [undefined, '']));
-	t.throws(() => matcher.isMatch([undefined], [undefined, undefined]));
-	t.throws(() => matcher.isMatch([undefined], [undefined]));
-	t.throws(() => matcher.isMatch([undefined], undefined));
+	t.false(matcher.isMatch([undefined], [undefined, '']));
+	t.false(matcher.isMatch([undefined], [undefined, undefined]));
+	t.false(matcher.isMatch([undefined], [undefined]));
+	t.false(matcher.isMatch([undefined], undefined));
 
-	t.throws(() => matcher.isMatch(['phoenix', undefined], [undefined]));
-	t.throws(() => matcher.isMatch([undefined, 'phoenix'], [undefined]));
-	t.throws(() => matcher.isMatch(['', undefined], [undefined]));
-	t.throws(() => matcher.isMatch([undefined, ''], [undefined]));
-	t.throws(() => matcher.isMatch([undefined, undefined], [undefined]));
-	t.throws(() => matcher.isMatch([undefined], [undefined]));
-	t.throws(() => matcher.isMatch(undefined, [undefined]));
+	t.false(matcher.isMatch(['phoenix', undefined], [undefined]));
+	t.false(matcher.isMatch([undefined, 'phoenix'], [undefined]));
+	t.false(matcher.isMatch(['', undefined], [undefined]));
+	t.false(matcher.isMatch([undefined, ''], [undefined]));
+	t.false(matcher.isMatch([undefined, undefined], [undefined]));
+	t.false(matcher.isMatch([undefined], [undefined]));
+	t.false(matcher.isMatch(undefined, [undefined]));
+
+	t.false(matcher.isMatch([], []));
+	t.false(matcher.isMatch([], ['*']));
+
+	t.throws(() => matcher(['phoenix'], [0]));
+	t.throws(() => matcher(['phoenix'], [null]));
+	t.throws(() => matcher(['phoenix'], [false]));
+	t.throws(() => matcher(['phoenix'], 0));
+	t.throws(() => matcher(['phoenix'], null));
+	t.throws(() => matcher(['phoenix'], false));
+
+	t.throws(() => matcher([0], ['bar']));
+	t.throws(() => matcher([null], ['bar']));
+	t.throws(() => matcher([false], ['bar']));
+	t.throws(() => matcher(0, ['bar']));
+	t.throws(() => matcher(null, ['bar']));
+	t.throws(() => matcher(false, ['bar']));
+
+	t.throws(() => matcher.isMatch(['phoenix'], [0]));
+	t.throws(() => matcher.isMatch(['phoenix'], [null]));
+	t.throws(() => matcher.isMatch(['phoenix'], [false]));
+	t.throws(() => matcher.isMatch(['phoenix'], 0));
+	t.throws(() => matcher.isMatch(['phoenix'], null));
+	t.throws(() => matcher.isMatch(['phoenix'], false));
+
+	t.throws(() => matcher.isMatch([0], ['bar']));
+	t.throws(() => matcher.isMatch([null], ['bar']));
+	t.throws(() => matcher.isMatch([false], ['bar']));
+	t.throws(() => matcher.isMatch(0, ['bar']));
+	t.throws(() => matcher.isMatch(null, ['bar']));
+	t.throws(() => matcher.isMatch(false, ['bar']));
 });


### PR DESCRIPTION

Fixes #22 - see discussion there first :)

Currently, matcher has a lot of undocumented / inconsistent behaviour when dealing with empty arguments. This PR standardises and documents a lot of those edge cases, hopefully making it easier to use this package with predictable outcomes.

## Breaking changes
- When passing an empty array of rules to `matcher()`, it would return the entire array of inputs with no filtering. Now it will return an empty array.

- When passing an empty array of rules to `matcher.isMatch()`, it would always return `true`. Now it will always return `false`.

- In certain cases it was possible to pass unsupported variable types to the functions and still receive a normal return value. This is no longer possible because of explicit type checks. This would have been very buggy to use, and should not have been used in production, but it is still a breaking change.

## New functionality
- `matcher()` now also supports passing a string instead of an array of strings. This simplifies the code base and makes the interface consistent with `matcher.isMatch()`.

- Both functions now fully support passing `undefined` variables to them. This was mostly supported before, but had several edge cases where it would crash the process. It was possible to ship code that seemed to work, but would crash under certain conditions.

## Minor fixes

- When passing unsupported variable types in the arrays of either function, they will now throw a proper `TypeError` with an explanation instead of crashing in all sorts of interesting ways.
